### PR TITLE
Adding loop-over-history functionality to replay-tx script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@eth-optimism/contracts": "^0.2.11",
-    "@eth-optimism/core-utils": "^0.1.5",
+    "@eth-optimism/core-utils": "^0.4.5",
     "@eth-optimism/data-transport-layer": "^0.1.0",
     "@eth-optimism/provider": "^0.0.1-alpha.14",
     "@ethersproject/providers": "^5.0.22",

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -1,120 +1,115 @@
-/**
- * Message replayer script
- * Requires a hash, network (string), and hash or block number
- * If block number provided, it loops over the transaction history and replays all failed txs
- */
-require("colors");
-const { Command } = require("commander");
-const log = require("single-line-log").stdout;
-const dotenv = require("dotenv").config();
-const { Contract, Wallet, utils } = require("ethers");
-const { getContractInterface } = require("@eth-optimism/contracts");
-const { JsonRpcProvider, InfuraProvider } = require("@ethersproject/providers");
-const program = new Command();
-
-program.requiredOption("-n, --network <string>", "specify network");
-program.requiredOption("-k, --key <number>", "specify private key");
-program.option("-h, --hash <number>", "specify transaction hash");
-program.option("-from, --fromBlock <number>", "specify a block number to start from");
-program.option("-to, --toBlock <number>", "specify a block number to end at");
-program.option("-c, --clearPendingTx", "clear a pending transaction");
-
-program.parse(process.argv);
-const argOptions = program.opts();
-
-if (argOptions.network !== "mainnet" && argOptions.network !== "kovan") {
-  console.error("Network must be 'mainnet' or 'kovan'");
-  process.exit();
-}
-
-if (!argOptions.hash && !argOptions.fromBlock) {
-  console.error("Must provide a hash or block number to start from.");
-  return;
-}
-const provider = new InfuraProvider(argOptions.network, process.env.INFURA_KEY);
-
-// Addresses from May 11 regenesis
-const MAINNET_L1_MESSENGER_PROXY = "0x902e5fF5A99C4eC1C21bbab089fdabE32EF0A5DF";
-const KOVAN_L1_MESSENGER_PROXY = "0x78b88FD62FBdBf67b9C5C6528CF84E9d30BB28e0";
-
-const messengerAddress = argOptions.network === "mainnet" ? MAINNET_L1_MESSENGER_PROXY : KOVAN_L1_MESSENGER_PROXY;
-
-const wallet = new Wallet(argOptions.key, provider);
-const proxyL1Messenger = new Contract(messengerAddress, getContractInterface("OVM_L1CrossDomainMessenger"), wallet);
+const { Command } = require("commander")
+const dotenv = require('dotenv')
+const ethers = require('ethers')
+const { getContractInterface, predeploys } = require('@eth-optimism/contracts')
 
 const main = async () => {
-  if (argOptions.clearPendingTx) {
-    latestTxCount = await wallet.getTransactionCount("latest");
-    pendingTxCount = await wallet.getTransactionCount("pending");
-    if (latestTxCount < pendingTxCount) {
-      console.log("Detected a pending transaction! Clearing it...");
-      await wallet.sendTransaction({
-        to: await wallet.getAddress(),
-        value: 0,
-        nonce: latestTxCount,
-      });
-    }
-    if (latestTxCount + 1 < pendingTxCount) {
-      console.log(
-        "Detected another pending transaction - exiting. Run this script again if you want to clear out the next transaction as well."
-      );
-      process.exit(1);
+  // Load environment variables from .env
+  dotenv.config()
+  const l1ProviderUrl = process.env.REPLAY__L1_RPC_PROVIDER_URL
+  const l2ProviderUrl = process.env.REPLAY__L2_RPC_PROVIDER_URL
+  const l1MessengerProxyAddress = process.env.REPLAY__L1_MESSENGER_PROXY_ADDRESS
+  const l1PrivateKey = process.env.REPLAY__L1_PRIVATE_KEY
+  
+  // Load the command line arguments
+  const program = new Command()
+  // Specify a hash if you want to replay a specific transaction
+  program.option("-h, --hash <number>", "specify transaction hash")
+  // Otherwise specify a from block and to block and replay all transactions within that range
+  program.option("-f, --from <number>", "specify a block number to start from")
+  program.option("-t, --to <number>", "specify a block number to end at")
+  program.parse(process.argv);
+  const opts = program.opts();
+  
+  if (!opts.hash && !opts.from) {
+    throw new Error('must provide either a transaction hash (--hash) or a starting block number (--from)')
+  }
+
+  const l1Provider = new ethers.providers.JsonRpcProvider(l1ProviderUrl)
+  const l2Provider = new ethers.providers.JsonRpcProvider(l2ProviderUrl)
+  const l1Wallet = new ethers.Wallet(l1PrivateKey, l1Provider)
+  const l1CrossDomainMessenger = new ethers.Contract(
+    l1MessengerProxyAddress,
+    getContractInterface('OVM_L1CrossDomainMessenger'),
+    l1Provider
+  )
+  const l2CrossDomainMessenger = new ethers.Contract(
+    predeploys.OVM_L2CrossDomainMessenger,
+    getContractInterface('OVM_L2CrossDomainMessenger'),
+    l2Provider
+  )
+
+  const replayMessages = async (transactionHash) => {
+    // Get the receipt so we can get the event logs.
+    const receipt = await l1Provider.getTransactionReceipt(transactionHash)
+  
+    // Decode the sent messages from the logs.
+    const decodedMessages = receipt.logs.filter((log) => {
+      return (
+        log.address === l1CrossDomainMessenger.address
+        && log.topics[0] === ethers.utils.id('SentMessage(bytes)')
+      )
+    }).map((log) => {
+      const [message] = ethers.utils.defaultAbiCoder.decode(['bytes'], log.data)
+      return l2CrossDomainMessenger.interface.decodeFunctionData('relayMessage', message)
+    })
+
+    // Replay the messages.
+    for (const message of decodedMessages) {
+      try {
+        const tx = await l1CrossDomainMessenger.connect(l1Wallet).replayMessage(
+          message._target,
+          message._sender,
+          message._message,
+          message._messageNonce,
+          3000000
+        )
+        await tx.wait()
+        console.log("success! tx hash:", tx.hash)
+      } catch (err) {
+        console.log(err)
+      }
     }
   }
-  if (argOptions.hash) {
-    replayMessage(argOptions.hash);
+
+  if (opts.hash) {
+    console.log(`Attempting to replay messages for tx: ${opts.hash}`)
+    await replayMessages(opts.hash)
   } else {
-    // Replay all transactions from provided toBlock number
-    try {
-      const logParams = {
-        address: messengerAddress,
-        topics: [utils.id(`SentMessage(bytes)`)],
-        fromBlock: Number(argOptions.fromBlock),
-      };
-      if (argOptions.toBlock) {
-        logParams.toBlock = Number(argOptions.toBlock);
+    // First find all L1 => L2 messages sent within the block range
+    const events = await l1CrossDomainMessenger.queryFilter(
+      l1CrossDomainMessenger.filters.SentMessage(),
+      Number(opts.from),
+      opts.to ? Number(opts.to) : undefined
+    )
+
+    // Find all L2 status events. In the future this may have to be refactored if there are too
+    // many events and we're required to paginate. Alternatively, we could index the event args
+    // and avoid this issue entirely but that requires a regenesis.
+    const l2SuccessEvents = await l2CrossDomainMessenger.queryFilter(
+      l2CrossDomainMessenger.filters.RelayedMessage(),
+    )
+    const l2FailureEvents = await l2CrossDomainMessenger.queryFilter(
+      l2CrossDomainMessenger.filters.FailedRelayedMessage(),
+    )
+    const l2Events = l2SuccessEvents.concat(l2FailureEvents)
+
+    // For each L1 => L2 message, find the corresponding L2 status event. If none exists, then we
+    // should replay those messages.
+    for (const event of events) {
+      const matchingEvents = l2Events.filter((l2Event) => {
+        return l2Event.args.msgHash === ethers.utils.keccak256(event.args.message)
+      })
+
+      if (matchingEvents.length === 0) {
+        console.log(`Found unsuccessful message for event in tx: ${event.transactionHash}`)
+        console.log(`Attempting to replay message...`)
+        // await replayMessages(event.transactionHash)
+      } else {
+        console.log(`Found successful message for event in tx: ${event.transactionHash}`)
       }
-      const logs = await provider.getLogs(logParams);
-      const txHashes = logs.map((log) => log.transactionHash);
-      for (const txHash of txHashes) {
-        await replayMessage(txHash);
-      }
-    } catch (err) {
-      console.error(err);
     }
   }
-};
+}
 
-const replayMessage = async (hash) => {
-  const l1MessengerProxy = argOptions.network === "mainnet" ? MAINNET_L1_MESSENGER_PROXY : KOVAN_L1_MESSENGER_PROXY;
-  const receipt = await provider.getTransactionReceipt(hash);
-
-  const decodedMessages = [];
-  for (const log of receipt.logs) {
-    if (log.address === l1MessengerProxy && log.topics[0] === utils.id("SentMessage(bytes)")) {
-      const [message] = utils.defaultAbiCoder.decode(["bytes"], log.data);
-
-      const xDomainInterface = getContractInterface("OVM_L2CrossDomainMessenger");
-      const decodedMessage = xDomainInterface.decodeFunctionData("relayMessage", message);
-      decodedMessages.push(decodedMessage);
-    }
-  }
-
-  for (const message of decodedMessages) {
-    try {
-      const tx = await proxyL1Messenger.replayMessage(
-        message._target,
-        message._sender,
-        message._message,
-        message._messageNonce,
-        3000000
-      );
-      await tx.wait();
-      console.log("success! tx hash:", tx.hash);
-    } catch (err) {
-      console.log(err);
-    }
-  }
-};
-
-main();
+main()

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -26,7 +26,7 @@ if (argOptions.network !== "mainnet" && argOptions.network !== "kovan") {
   process.exit();
 }
 
-if (!argOptions.hash && !argOptions.toBlock) {
+if (!argOptions.hash && !argOptions.fromBlock) {
   console.error("Must provide a hash or block number to start from.");
   return;
 }

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -10,7 +10,7 @@ const main = async () => {
   const l2ProviderUrl = process.env.REPLAY__L2_RPC_PROVIDER_URL
   const l1MessengerProxyAddress = process.env.REPLAY__L1_MESSENGER_PROXY_ADDRESS
   const l1PrivateKey = process.env.REPLAY__L1_PRIVATE_KEY
-  
+
   // Load the command line arguments
   const program = new Command()
   // Specify a hash if you want to replay a specific transaction
@@ -104,7 +104,7 @@ const main = async () => {
       if (matchingEvents.length === 0) {
         console.log(`Found unsuccessful message for event in tx: ${event.transactionHash}`)
         console.log(`Attempting to replay message...`)
-        // await replayMessages(event.transactionHash)
+        await replayMessages(event.transactionHash)
       } else {
         console.log(`Found successful message for event in tx: ${event.transactionHash}`)
       }

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -1,3 +1,8 @@
+/**
+ * Message replayer script
+ * Requires a hash, network (string), and hash or block number
+ * If block number provided, it loops over the transaction history and replays all failed txs
+ */
 require("colors");
 const { Command } = require("commander");
 const log = require("single-line-log").stdout;
@@ -7,25 +12,43 @@ const { getContractInterface } = require("@eth-optimism/contracts");
 const { JsonRpcProvider, getDefaultProvider } = require("@ethersproject/providers");
 const program = new Command();
 
-program.requiredOption("-h, --hash <number>", "specify transaction hash");
 program.requiredOption("-n, --network <string>", "specify network");
-program.option("-k, --key <number>", "specify private key");
+program.requiredOption("-k, --key <number>", "specify private key");
+program.option("-h, --hash <number>", "specify transaction hash");
+program.option("-b, --blockNumber <number>", "specify a block number");
+
 program.parse(process.argv);
 const argOptions = program.opts();
 
 const mainnetProvider = getDefaultProvider(argOptions.network);
 
-const L1_MESSENGER_PROXY = "0xD1EC7d40CCd01EB7A305b94cBa8AB6D17f6a9eFE";
+// Addresses from May 11 regenesis
+const MAINNET_L1_MESSENGER_PROXY = "0x902e5fF5A99C4eC1C21bbab089fdabE32EF0A5DF";
+const KOVAN_L1_MESSENGER_PROXY = "0x78b88FD62FBdBf67b9C5C6528CF84E9d30BB28e0";
 
 const wallet = new Wallet(argOptions.key, mainnetProvider);
 const proxyL1Messenger = new Contract(L1_MESSENGER_PROXY, getContractInterface("OVM_L1CrossDomainMessenger"), wallet);
 
 const main = async () => {
-  const receipt = await mainnetProvider.getTransactionReceipt(argOptions.hash);
+  if (!argOptions.hash && !argOptions.blockNumber) {
+    console.error("Must provide a hash or block number.");
+    return;
+  }
+
+  if (argOptions.hash) {
+    replayMessage(argOptions.hash);
+  } else {
+    // TODO: loop over blocks starting at argOptions.blockNumber, get all failed transactions and replay them
+  }
+};
+
+const replayMessage = async (hash) => {
+  const l1MessengerProxy = argOptions.network === "mainnet" ? MAINNET_L1_MESSENGER_PROXY : KOVAN_L1_MESSENGER_PROXY;
+  const receipt = await mainnetProvider.getTransactionReceipt(hash);
 
   const decodedMessages = [];
   for (const log of receipt.logs) {
-    if (log.address === L1_MESSENGER_PROXY && log.topics[0] === utils.id("SentMessage(bytes)")) {
+    if (log.address === l1MessengerProxy && log.topics[0] === utils.id("SentMessage(bytes)")) {
       const [message] = utils.defaultAbiCoder.decode(["bytes"], log.data);
 
       const xDomainInterface = getContractInterface("OVM_L2CrossDomainMessenger");

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -44,19 +44,21 @@ const proxyL1Messenger = new Contract(messengerAddress, getContractInterface("OV
 
 const main = async () => {
   if (argOptions.clearPendingTx) {
-    latestTxCount = await wallet.getTransactionCount('latest')
-    pendingTxCount = await wallet.getTransactionCount('pending')
+    latestTxCount = await wallet.getTransactionCount("latest");
+    pendingTxCount = await wallet.getTransactionCount("pending");
     if (latestTxCount < pendingTxCount) {
-      console.log('Detected a pending transaction! Clearing it...')
+      console.log("Detected a pending transaction! Clearing it...");
       await wallet.sendTransaction({
         to: await wallet.getAddress(),
         value: 0,
-        nonce: latestTxCount
-      })
+        nonce: latestTxCount,
+      });
     }
     if (latestTxCount + 1 < pendingTxCount) {
-      console.log('Detected another pending transaction - exiting. Run this script again if you want to clear out the next transaction as well.')
-      process.exit(1)
+      console.log(
+        "Detected another pending transaction - exiting. Run this script again if you want to clear out the next transaction as well."
+      );
+      process.exit(1);
     }
   }
   if (argOptions.hash) {
@@ -100,13 +102,15 @@ const replayMessage = async (hash) => {
 
   for (const message of decodedMessages) {
     try {
-      await proxyL1Messenger.replayMessage(
+      const tx = await proxyL1Messenger.replayMessage(
         message._target,
         message._sender,
         message._message,
         message._messageNonce,
         3000000
       );
+      await tx.wait();
+      console.log("success! tx hash:", tx.hash);
     } catch (err) {
       console.log(err);
     }

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -48,9 +48,10 @@ const main = async () => {
     try {
       const logs = await provider.getLogs({
         address: messengerAddress,
-        topics: [utils.id(`RelayedMessage(bytes32)`)],
-        fromBlock: Number(argOptions.blockNumber,
+        topics: [utils.id(`SentMessage(bytes)`)],
+        fromBlock: Number(argOptions.blockNumber),
       });
+
       const txHashes = logs.map((log) => log.transactionHash);
       for (const txHash of txHashes) {
         await replayMessage(txHash);

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,15 @@
     ethers "^5.0.31"
     lodash "^4.17.21"
 
+"@eth-optimism/core-utils@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.4.5.tgz#a3ad0c780ddb3fa9b20fe595f78401d993606d71"
+  integrity sha512-nG5bj3Okk9z8ALLS3fbBpAzU3tMZIDbwB32zQejGy0ZFqIA8XWNbuhC1i53qPQCwKJITtSufXYPCDGXu1exlqQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.0.9"
+    ethers "^5.0.31"
+    lodash "^4.17.21"
+
 "@eth-optimism/data-transport-layer@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@eth-optimism/data-transport-layer/-/data-transport-layer-0.1.0.tgz#49813320bd4afa287b4aebfe01e5d57fe4325cfa"


### PR DESCRIPTION
Attempting to finish the work described here: https://github.com/ethereum-optimism/optimism/issues/705

- update watcher to return failed txs using new event referenced here: https://github.com/ethereum-optimism/optimism/issues/602
- get all failed txs from provided `blockNumber` & replay them