### PR TITLE
Add a tx clearer to the withdrawal replayer

### DIFF
--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -17,6 +17,7 @@ program.requiredOption("-k, --key <number>", "specify private key");
 program.option("-h, --hash <number>", "specify transaction hash");
 program.option("-from, --fromBlock <number>", "specify a block number to start from");
 program.option("-to, --toBlock <number>", "specify a block number to end at");
+program.option("-c, --clearTxs", "clear ");
 
 program.parse(process.argv);
 const argOptions = program.opts();
@@ -42,6 +43,22 @@ const wallet = new Wallet(argOptions.key, provider);
 const proxyL1Messenger = new Contract(messengerAddress, getContractInterface("OVM_L1CrossDomainMessenger"), wallet);
 
 const main = async () => {
+  if (argOptions.clearTxs) {
+    latestTxCount = await wallet.getTransactionCount('latest')
+    pendingTxCount = await wallet.getTransactionCount('pending')
+    if (latestTxCount < pendingTxCount) {
+      console.log('Detected a pending transaction! Clearing it...')
+      await wallet.sendTransaction({
+        to: await wallet.getAddress(),
+        value: 0,
+        nonce: latestTxCount
+      })
+    }
+    if (latestTxCount + 1 < pendingTxCount) {
+      console.log('Detected another pending transaction - exiting. Run this script again if you want to clear out the next transaction as well.')
+      process.exit(1)
+    }
+  }
   if (argOptions.hash) {
     replayMessage(argOptions.hash);
   } else {

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -17,7 +17,7 @@ program.requiredOption("-k, --key <number>", "specify private key");
 program.option("-h, --hash <number>", "specify transaction hash");
 program.option("-from, --fromBlock <number>", "specify a block number to start from");
 program.option("-to, --toBlock <number>", "specify a block number to end at");
-program.option("-c, --clearTxs", "clear ");
+program.option("-c, --clearPendingTx", "clear a pending transaction");
 
 program.parse(process.argv);
 const argOptions = program.opts();

--- a/scripts/replay-tx.js
+++ b/scripts/replay-tx.js
@@ -43,7 +43,7 @@ const wallet = new Wallet(argOptions.key, provider);
 const proxyL1Messenger = new Contract(messengerAddress, getContractInterface("OVM_L1CrossDomainMessenger"), wallet);
 
 const main = async () => {
-  if (argOptions.clearTxs) {
+  if (argOptions.clearPendingTx) {
     latestTxCount = await wallet.getTransactionCount('latest')
     pendingTxCount = await wallet.getTransactionCount('pending')
     if (latestTxCount < pendingTxCount) {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR allows you to clear a pending transaction if the withdrawal relayer gets stuck.
